### PR TITLE
chore: add dde-api-proxy for v23 beta

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-environment (2023.04.20) unstable; urgency=medium
+
+  * add dde-api-proxy for deepin v23 beta release
+
+ -- Wang Zichong <wangzichong@deepin.org>  Thu, 20 Apr 2023 13:16:00 +0800
+
 deepin-desktop-environment (2023.03.31) unstable; urgency=medium
 
   * remove rsyslog 

--- a/debian/control
+++ b/debian/control
@@ -260,7 +260,8 @@ Depends: ${misc:Depends},
  deepin-kwin-wayland,
  dde-session,
  dde-permission-manager,
- dde-application-manager
+ dde-application-manager,
+ dde-api-proxy
 Recommends:
  cups,
  ttf-deepin-opensymbol


### PR DESCRIPTION
为 v23 beta 发布版本添加 v20 dbus 兼容接口。

此兼容用软件包会在 deepin v23 正式版前移除，因 beta 时仍有应用未完成迁移的项目，故暂时预装此兼容包。

相关 Issue：

- https://github.com/linuxdeepin/developer-center/issues/4129
- https://github.com/linuxdeepin/developer-center/issues/4134