### PR TITLE
feat: Do not depend on uos-license-content

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-environment (2024.01.25) unstable; urgency=medium
+
+  * d/control: Do not depend on uos-license-content.
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Thu, 25 Jan 2024 15:36:13 +0800
+
 deepin-desktop-environment (2024.01.22) unstable; urgency=medium
 
   * update linglong repos.

--- a/debian/control
+++ b/debian/control
@@ -281,7 +281,6 @@ Depends: ${misc:Depends},
          simple-scan,
          systemd-timesyncd,
          uimg-installer [!riscv64 !loong64],
-         uos-license-content [!riscv64 !loong64],
          uos-ai [amd64],
          dcc-insider-plugin,
 	 fcitx5-frontend-qt6


### PR DESCRIPTION
uos-license-content is UOS only. deepin license stores in /usr/share/deepin-deepinid-client/.
