### PR TITLE
fix: linglong repo config.yaml permissions error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-environment (2024.05.29) unstable; urgency=medium
+
+  * fix: linglong repo config.yaml permissions error
+
+ -- dengbo <dengbo<dengbo@deepin.org>>  Tue, 28 May 2024 17:38:01 +0800
+
 deepin-desktop-environment (2024.05.28) unstable; urgency=medium
 
   * add intel-media-va-driver-non-free [amd64]

--- a/debian/deepin-desktop-environment-ll.postinst
+++ b/debian/deepin-desktop-environment-ll.postinst
@@ -25,7 +25,7 @@ install_pkg(){
 
 
 update_ll_repo-dev(){
-cat > /var/lib/linglong/config.yaml<< EOF
+cat > /usr/share/linglong/config.yaml<< EOF
 # SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
@@ -38,7 +38,7 @@ EOF
 }
 
 update_ll_repo(){
-cat > /var/lib/linglong/config.yaml<< EOF
+cat > /usr/share/linglong/config.yaml<< EOF
 # SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later


### PR DESCRIPTION
linglong repo config.yaml permissions must be deepin-linglong, can not write this file when make mirror or permissions will be root, use /usr/share/linglong/config.yaml to replace /var/lib/linglong/config.yaml

Log: