### PR TITLE
chore: add depends deepin-network-displays

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -204,6 +204,7 @@ Depends: ${misc:Depends},
          plymouth-theme-deepin-logo,
          startdde,
          deepin-osconfig,
+         deepin-network-displays,
 Recommends: cups,
             ttf-deepin-opensymbol,
 Description: Deepin New Desktop Environment - Next


### PR DESCRIPTION
add depends deepin-network-displays