### PR TITLE
fix: linglong repo error in mirror

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-environment (2025.02.28) unstable; urgency=medium
+
+  * release 2025.02.28.
+
+ -- dengbo <dengbo@deepin.org>  Fri, 28 Feb 2025 11:26:14 +0800
+
 deepin-desktop-environment (2024.12.07) unstable; urgency=medium
 
   * update depends.

--- a/debian/deepin-desktop-environment-ll.postinst
+++ b/debian/deepin-desktop-environment-ll.postinst
@@ -20,36 +20,6 @@ install_pkg(){
     done
 }
 
-
-
-
-
-update_ll_repo-dev(){
-cat > /usr/share/linglong/config.yaml<< EOF
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
-#
-# SPDX-License-Identifier: LGPL-3.0-or-later
-
-version: 1
-defaultRepo: old
-repos:
-  old: http://repo-dev.cicd.getdeepin.org
-EOF
-}
-
-update_ll_repo(){
-cat > /usr/share/linglong/config.yaml<< EOF
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
-#
-# SPDX-License-Identifier: LGPL-3.0-or-later
-
-version: 1
-defaultRepo: stable
-repos:
-  stable: https://mirror-repo-linglong.deepin.com
-EOF
-}
-
 remove_confing(){
 
 	if [ -f /var/lib/linglong/config.yaml ]; then
@@ -63,10 +33,11 @@ if [ "$1" = "configure" ] && [ "$2" = "" ]; then
 	if [ -f /usr/libexec/linglong/create-linglong-dirs ]; then
 		/usr/libexec/linglong/create-linglong-dirs
 	fi
-	update_ll_repo-dev
+	sudo ll-cli --no-dbus repo add old http://repo-dev.cicd.getdeepin.org
+	sudo ll-cli --no-dbus repo set-default old
 	install_pkg ${LL_pkgList}
-	update_ll_repo
-
+	sudo ll-cli --no-dbus repo set-default stable
+	sudo ll-cli --no-dbus repo remove old
 fi
 
 


### PR DESCRIPTION
Change linglong repo by ll-cli repo.

## Summary by Sourcery

Updates the Linglong repository to resolve an error, switching from the previous repository to the ll-cli repository in the post installation script.

Bug Fixes:
- Fixes an error related to the Linglong repository by switching to the ll-cli repository.

Build:
- Updates the post installation script for the deepin-desktop-environment-ll package to use the ll-cli repository.