### PR TITLE
25/lao oem

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-environment (2025.08.11) unstable; urgency=medium
+
+  * add remove org.deepin.browser
+
+ -- lichenggang <lichenggang@deepin.org>  Mon, 11 Aug 2025 16:34:58 +0800
+
 deepin-desktop-environment (2025.07.29) unstable; urgency=medium
 
   * add usec-boot-crypt.

--- a/packages.linglong.amd64
+++ b/packages.linglong.amd64
@@ -5,7 +5,7 @@ org.deepin.draw
 org.deepin.editor
 org.deepin.movie
 org.deepin.reader
-org.deepin.browser
+#org.deepin.browser
 org.deepin.mail
 org.deepin.camera
 org.deepin.fontmanager


### PR DESCRIPTION
## Summary by Sourcery

Revamp Debian packaging for the Deepin Lao OEM (linglong) variant by replacing obsolete scripts, restructuring install files, and adding architecture-specific package lists.

Build:
- Remove debian/compat file and deprecated generic packages.linglong entry
- Replace deepin-desktop-environment-ll.postinst with deepin-desktop-environment-extras.postinst
- Add architecture-specific Linglong package lists for amd64, arm64, and loong64
- Update debian/control, changelog, and install files to reflect packaging changes